### PR TITLE
fix: use Dock Accessibility API for badge count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,24 +54,28 @@ The favicon is rendered client-side: a green iMessage-style speech bubble, with 
 - **Commit format**: Conventional commits — `feat:`, `fix:`, `docs:`, `chore:`
 - **Issue closing**: Each issue needs its own `closes` keyword: `Closes #1, closes #2`
 
-## How lsappinfo Works
+## How the Dock Badge Read Works
 
-```bash
-lsappinfo -all info -only StatusLabel com.apple.MobileSMS
+```applescript
+tell application "System Events" to tell process "Dock"
+    return value of attribute "AXStatusLabel" of UI element "Messages" of list 1
+end tell
 ```
 
-Returns:
-- `"StatusLabel"=[ NULL ]` — Messages running, 0 unread
-- `"StatusLabel"=[ "label"="5" ]` — Messages running, 5 unread
-- Empty output — Messages not running
+Returns the integer badge count (e.g., `3`), or `missing value` when badge is 0.
 
-This matches the actual dock badge exactly, unlike direct SQLite queries on `chat.db` which return stale iCloud sync data.
+This reads the actual dock badge via the macOS Accessibility API. It requires the calling process (Terminal, Python, etc.) to have **Accessibility permission** (System Settings > Privacy & Security > Accessibility).
+
+### Why not other approaches?
+
+- **`lsappinfo`**: Returns `NULL` for Messages on macOS Tahoe even when the badge is visible. Messages doesn't use the standard `NSDockTile.badgeLabel` API.
+- **SQLite on `chat.db`**: `is_read` flag has massive stale data from iCloud sync (1840 phantom unreads vs actual 0). `last_read_message_timestamp` is also unreliable.
 
 ## Decision Log
 
 | Date | Decision | Rationale |
 |------|----------|-----------|
-| 2026-03-31 | Use `lsappinfo` instead of SQLite on `chat.db` | Direct DB queries return stale iCloud sync data (1840 phantom unreads vs actual 0). `lsappinfo` returns the exact dock badge count. |
+| 2026-03-31 | Use Dock Accessibility API (`AXStatusLabel`) instead of `lsappinfo` or SQLite | `lsappinfo` returns NULL for Messages on Tahoe. SQLite `chat.db` has stale iCloud sync data. The Dock accessibility API returns the exact visible badge. |
 | 2026-03-31 | Single-file, stdlib-only Python server | Zero supply chain risk, no pip install needed, simplest possible deployment. |
 | 2026-03-31 | Client-side Canvas for favicon rendering | Avoids Pillow or any server-side image dependency. Browser Canvas API draws the bubble + badge. |
 | 2026-03-31 | Bind to `0.0.0.0` by default | Primary use case is LAN access from another machine. Configurable via `--bind` for localhost-only. |

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Pin it as a tab, or create a web app (e.g., in Microsoft Edge or Chrome) to get 
 
 ## Requirements
 
-- **macOS** (uses `lsappinfo`, a built-in macOS utility)
+- **macOS** (uses the Dock Accessibility API via `osascript`)
 - **Python 3.11+** (stdlib only — no `pip install` needed)
 - **Messages app** must be running (the server reads the dock badge count)
+- **Accessibility permission** for Terminal (or whichever app runs the server) — grant in System Settings > Privacy & Security > Accessibility
 
 ## Quick Start
 
@@ -36,7 +37,7 @@ python3 server.py --bind 127.0.0.1  # localhost only
 
 ## How It Works
 
-The server calls `lsappinfo` to read the Messages app's dock badge count — the same number macOS displays on the Messages icon in your Dock. This is more reliable than querying the Messages SQLite database directly, which can return stale data due to iCloud sync.
+The server uses the macOS Dock Accessibility API (via `osascript`) to read the Messages app's dock badge count — the exact number macOS displays on the Messages icon in your Dock. This is more reliable than `lsappinfo` (which returns NULL for Messages on recent macOS) or querying the Messages SQLite database directly (which returns stale data due to iCloud sync).
 
 The webpage polls `/api/count` at the configured interval and uses the HTML Canvas API to render a dynamic favicon: a green iMessage-style speech bubble with a red badge showing the unread count.
 

--- a/server.py
+++ b/server.py
@@ -180,30 +180,42 @@ APPLE_TOUCH_ICON_SVG = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1
 
 
 def get_unread_count():
-    """Read the Messages dock badge count via lsappinfo.
+    """Read the Messages dock badge count via the Dock accessibility API.
+
+    Uses AppleScript to query the AXStatusLabel attribute of the Messages
+    element in the Dock. This matches the actual dock badge exactly, unlike
+    lsappinfo (which returns NULL for Messages on macOS Tahoe) or direct
+    SQLite queries on chat.db (which return stale iCloud sync data).
+
+    Requires: Accessibility permission for the calling process.
 
     Returns:
         tuple: (count: int, error: str | None)
     """
     try:
         result = subprocess.run(
-            ["lsappinfo", "-all", "info", "-only", "StatusLabel",
-             "com.apple.MobileSMS"],
+            ["osascript", "-e",
+             'tell application "System Events" to tell process "Dock" '
+             'to return value of attribute "AXStatusLabel" of UI element '
+             '"Messages" of list 1'],
             capture_output=True, text=True, timeout=5,
         )
         output = result.stdout.strip()
-        if not output:
-            return 0, "Messages app is not running"
-        if "NULL" in output:
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "missing value" in stderr or "missing value" in output:
+                return 0, None
+            return 0, "Could not read Messages badge (check Accessibility permissions)"
+        if not output or output == "missing value":
             return 0, None
-        match = re.search(r'"label"="(\d+)"', output)
-        if match:
-            return int(match.group(1)), None
-        return 0, f"Unexpected lsappinfo output"
+        try:
+            return int(output), None
+        except ValueError:
+            return 0, None
     except FileNotFoundError:
-        return 0, "lsappinfo not found (macOS only)"
+        return 0, "osascript not found (macOS only)"
     except subprocess.TimeoutExpired:
-        return 0, "lsappinfo timed out"
+        return 0, "osascript timed out"
     except Exception as e:
         return 0, str(e)
 


### PR DESCRIPTION
## Summary
- `lsappinfo` returns NULL for Messages on macOS Tahoe — it doesn't use the standard `NSDockTile.badgeLabel` API
- Switched to Dock Accessibility API (`AXStatusLabel` via `osascript`) which returns the exact visible badge value
- Updated README and CLAUDE.md to document the new approach and Accessibility permission requirement

Closes #4

## Test plan
- [x] `/api/count` returns correct count matching dock badge
- [x] Verified with 4 actual unread messages
- [x] Error handling for missing Accessibility permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)