### PR TITLE
feat: add LaunchAgent example for auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ Then open `http://localhost:8429` in your browser. From another machine on your 
 
 To create a persistent "app" in Edge: navigate to the URL, then **Settings > Apps > Install this site as an app**.
 
+## Auto-Start (LaunchAgent)
+
+To start the server automatically on login, copy and customize the example plist:
+
+```bash
+# Edit the example — update Label, Python path, and script path for your system
+cp messages-icon.plist.example ~/Library/LaunchAgents/com.example.messages-icon.plist
+vi ~/Library/LaunchAgents/com.example.messages-icon.plist
+
+# Load
+launchctl load ~/Library/LaunchAgents/com.example.messages-icon.plist
+
+# Unload
+launchctl unload ~/Library/LaunchAgents/com.example.messages-icon.plist
+```
+
+To customize port, poll interval, or bind address, add flags to the `ProgramArguments` array in the plist (e.g., `--port`, `--poll-interval`, `--bind`).
+
+> **Note:** The Python process running the server needs **Accessibility permission** (System Settings > Privacy & Security > Accessibility) to read the dock badge.
+
 ## Configuration
 
 | Option | CLI Arg | Env Var | Default |

--- a/messages-icon.plist.example
+++ b/messages-icon.plist.example
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.messages-icon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/python3</string>
+        <string>/path/to/messages-icon/server.py</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/messages-icon.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/messages-icon.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add `messages-icon.plist.example` with generic paths for users to customize
- README documents install/uninstall steps and Accessibility permission requirement
- Example uses `KeepAlive` to restart automatically if the process exits

Closes #1

## Test plan
- [x] Installed personalized plist, loaded via `launchctl load`
- [x] Server starts on login and responds on port 8429
- [x] `/api/count` returns correct badge count (verified with 5 unread)
- [x] `KeepAlive` restarts server after kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)