### PR TITLE
fix: use ThreadingHTTPServer to prevent hang on half-open connections

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,7 +8,7 @@ import re
 import ssl
 import subprocess
 import sys
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 HTML_TEMPLATE = '''<!DOCTYPE html>
@@ -407,7 +407,7 @@ def main():
 
     Handler.poll_interval = args.poll_interval
 
-    server = HTTPServer((args.bind, args.port), Handler)
+    server = ThreadingHTTPServer((args.bind, args.port), Handler)
 
     scheme = "http"
     if args.https:


### PR DESCRIPTION
## Summary
- Switch `server.py` from `HTTPServer` (single-threaded) to `ThreadingHTTPServer` so one wedged client can't block every subsequent request.

## Why
After ~10 days of uptime the service stopped responding — process alive, socket listening, but even `curl https://localhost:8429/api/count` from the server itself timed out. `lsof` showed an ESTABLISHED connection to a client that had gone away. Root cause: `BaseHTTPRequestHandler` has no read timeout on the request line, so a half-open TCP connection made the single-threaded server block forever in `recv()`.

Closes #11

## Test plan
- [ ] Run `python3 server.py --https` locally, load the page, confirm favicon + badge still work
- [ ] Restart the LaunchAgent (`launchctl kickstart -k gui/$(id -u)/net.midwood.messages-icon`) and hit from another machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)