### PR TITLE
fix(#13): use self-disclaiming Swift helper for dock badge access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ venv/
 .DS_Store
 ._*
 
+# Compiled helper binary (build with helper/build.sh)
+helper/dock-badge-reader
+
 # Claude Code local settings
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ python3 server.py --bind 127.0.0.1
 Single-file server (`server.py`) with four HTTP routes:
 
 - `GET /` — HTML page with inline CSS/JS. JavaScript polls the API and uses `navigator.setAppBadge()` to update the PWA dock badge.
-- `GET /api/count` — Returns JSON `{"unread": N}`. Calls `osascript` to read the Messages dock badge via the Accessibility API.
+- `GET /api/count` — Returns JSON `{"unread": N}`. Invokes the compiled `helper/dock-badge-reader` binary (a Swift Mach-O that calls the Accessibility API directly). The helper — not Python — is the TCC subject for the Accessibility grant.
 - `GET /apple-touch-icon.png` — Returns a green bubble SVG icon for iOS home screen bookmarks and PWA install.
 - `GET /manifest.json` — PWA web app manifest for "Install as app" flow.
 
@@ -64,15 +64,31 @@ The favicon is a plain green iMessage-style speech bubble rendered client-side v
 
 ## How the Dock Badge Read Works
 
+`server.py` invokes `helper/dock-badge-reader` (a small Swift Mach-O, source in `helper/dock-badge-reader.swift`). The helper calls the Accessibility API directly: gets the Dock process via `NSWorkspace`, walks `AXChildren` to find the first `AXList`, finds the tile with `AXTitle == "Messages"`, and reads its `AXStatusLabel` attribute. Prints the integer count to stdout, or `0` when the badge is empty.
+
+The equivalent AppleScript (no longer used — kept for reference) was:
+
 ```applescript
 tell application "System Events" to tell process "Dock"
     return value of attribute "AXStatusLabel" of UI element "Messages" of list 1
 end tell
 ```
 
-Returns the integer badge count (e.g., `3`), or `missing value` when badge is 0.
+**TCC requirement:** the helper binary itself must be granted **Accessibility** in System Settings > Privacy & Security > Accessibility. Python is no longer the TCC subject — see Decision Log entry for 2026-04-30 and [issue #13](https://github.com/brentmid/messages-icon/issues/13).
 
-This reads the actual dock badge via the macOS Accessibility API. It requires the calling process (Terminal, Python, etc.) to have **Accessibility permission** (System Settings > Privacy & Security > Accessibility).
+### Building the helper
+
+```bash
+./helper/build.sh
+```
+
+Compiles with `swiftc -O`, ad-hoc signs with `codesign -s -`. Output: `helper/dock-badge-reader` (gitignored). Build once and leave alone — every rebuild changes the cdhash and invalidates the TCC grant. Only rebuild when actually fixing the helper.
+
+### Why the helper self-disclaims
+
+The helper's first action on startup is to `posix_spawn` a copy of itself with `responsibility_spawnattrs_setdisclaim(attr, 1)` and wait for it. This is **required**, not optional. Without it, when the helper is spawned by Python under launchd, TCC checks Python as the responsible process — not the helper — and denies the request even though the helper has its own Accessibility grant. The disclaimed child becomes its own responsible process, so TCC then consults the helper's grant. A `--disclaimed` argv sentinel lets the same binary act as both parent (re-execs with disclaim) and child (does the AX work). Confirmed via tccd's `AUTHREQ_SUBJECT` log entry — with disclaim, subject = helper path; without, subject = Python path.
+
+Apply the same pattern to any future per-project TCC helper. See `~/bin/CLAUDE.md` "TCC permission helpers" for the cross-project rule.
 
 ### Why not other approaches?
 
@@ -90,3 +106,5 @@ This reads the actual dock badge via the macOS Accessibility API. It requires th
 | 2026-03-31 | HTTPS with auto-generated self-signed cert | PWA Badging API (`navigator.setAppBadge()`) requires a secure context (HTTPS). Auto-generate cert on first `--https` run, include machine hostname in SANs. |
 | 2026-03-31 | No count in favicon, use PWA Badging API | Drawing a red badge in the Canvas AND having the PWA badge creates a "double badge". Favicon is just the green bubble; the OS-level PWA badge shows the count. |
 | 2026-03-31 | PWA manifest (`/manifest.json`) | Enables "Install as app" in Edge/Chrome and declares the app as standalone for proper PWA behavior. |
+| 2026-04-30 | Replace `osascript`-via-Python with a compiled Swift helper at `helper/dock-badge-reader` | Granting Accessibility to a Homebrew Python (the prior approach) silently broke on every Homebrew bump because the cellar path and binary signature changed. The compiled helper is a single-purpose Mach-O with a stable cdhash that holds the TCC grant across Python upgrades. See [issue #13](https://github.com/brentmid/messages-icon/issues/13). Cross-references: `~/bin/CLAUDE.md` "TCC permission helpers" section, and `edr/issues/0041`. |
+| 2026-04-30 | Helper self-disclaims TCC responsibility via `responsibility_spawnattrs_setdisclaim` + self-re-exec | Direct invocation alone wasn't sufficient. Empirically (tccd `AUTHREQ_SUBJECT` log) Python was still being checked as the responsible process even though Python only `subprocess.run`s the helper. Without disclaim the request was denied despite the helper having its own grant. The helper's first action on startup is to `posix_spawn` a copy of itself with the disclaim attribute, wait, and propagate the child's exit code; the disclaimed child does the AX work as its own responsible process. A `--disclaimed` argv sentinel differentiates parent/child. |

--- a/README.md
+++ b/README.md
@@ -6,19 +6,25 @@ Pin it as a tab, or create a web app (e.g., in Microsoft Edge or Chrome) to get 
 
 ## Requirements
 
-- **macOS** (uses the Dock Accessibility API via `osascript`)
+- **macOS** (uses the Dock Accessibility API)
 - **Python 3.11+** (stdlib only — no `pip install` needed)
+- **Xcode Command Line Tools** (for building the dock-badge helper — `swiftc`, `codesign`)
 - **Messages app** must be running (the server reads the dock badge count)
-- **Accessibility permission** for Terminal (or whichever app runs the server) — grant in System Settings > Privacy & Security > Accessibility
+- **Accessibility permission** for the compiled `helper/dock-badge-reader` binary — grant in System Settings > Privacy & Security > Accessibility (see Quick Start below)
 
 ## Quick Start
 
 ```bash
-# Basic (HTTP) — works for browser tabs
-python3 server.py
+# 1. Build the dock-badge helper (one-time)
+./helper/build.sh
 
-# With HTTPS — required for PWA dock badge updates
-python3 server.py --https
+# 2. Grant Accessibility to the helper:
+#    System Settings → Privacy & Security → Accessibility → +
+#    Add: <repo>/helper/dock-badge-reader
+
+# 3. Run the server
+python3 server.py             # HTTP — works for browser tabs
+python3 server.py --https     # HTTPS — required for PWA dock badge
 ```
 
 Then open `https://localhost:8429` (or `http://` without `--https`) in your browser. From another machine on your LAN, use `https://<your-mac-ip>:8429`.
@@ -58,7 +64,7 @@ launchctl unload ~/Library/LaunchAgents/com.example.messages-icon.plist
 
 To customize port, poll interval, or bind address, add flags to the `ProgramArguments` array in the plist (e.g., `--port`, `--poll-interval`, `--bind`).
 
-> **Note:** The Python process running the server needs **Accessibility permission** (System Settings > Privacy & Security > Accessibility) to read the dock badge.
+> **Note:** Accessibility permission must be granted to the **compiled helper binary** (`helper/dock-badge-reader`), not to Python. The server invokes the helper as a subprocess; the helper is the TCC subject. See the Quick Start for the build/grant flow.
 
 ## Configuration
 
@@ -79,7 +85,9 @@ python3 server.py --bind 127.0.0.1  # localhost only
 
 ## How It Works
 
-The server uses the macOS Dock Accessibility API (via `osascript`) to read the Messages app's dock badge count — the exact number macOS displays on the Messages icon in your Dock. This is more reliable than `lsappinfo` (which returns NULL for Messages on recent macOS) or querying the Messages SQLite database directly (which returns stale data due to iCloud sync).
+The server uses the macOS Dock Accessibility API (via a small compiled Swift helper at `helper/dock-badge-reader`) to read the Messages app's dock badge count — the exact number macOS displays on the Messages icon in your Dock. This is more reliable than `lsappinfo` (which returns NULL for Messages on recent macOS) or querying the Messages SQLite database directly (which returns stale data due to iCloud sync).
+
+The helper exists so the TCC Accessibility grant binds to a tiny single-purpose binary with a stable signature, rather than to whichever Homebrew Python the LaunchAgent currently resolves. Homebrew Python upgrades silently invalidate TCC grants on the interpreter; the compiled helper avoids that whole class of breakage. See [issue #13](https://github.com/brentmid/messages-icon/issues/13) for the full reasoning.
 
 The webpage polls `/api/count` at the configured interval. When installed as a PWA (via Edge or Chrome) over HTTPS, it uses the Badging API (`navigator.setAppBadge()`) to show the unread count on the dock icon. The favicon is a green iMessage-style speech bubble rendered via Canvas.
 
@@ -91,10 +99,10 @@ The webpage polls `/api/count` at the configured interval. When installed as a P
 {"unread": 3}
 ```
 
-Or, if there's an issue (e.g., Accessibility permission not granted):
+Or, if there's an issue (e.g., Accessibility permission not granted to the helper, or the helper isn't built):
 
 ```json
-{"unread": 0, "error": "Could not read Messages badge (check Accessibility permissions)"}
+{"unread": 0, "error": "Accessibility permission missing for dock-badge-reader helper"}
 ```
 
 ## Privacy

--- a/helper/build.sh
+++ b/helper/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Build the dock-badge-reader helper.
+#
+# Compiles dock-badge-reader.swift with swiftc, ad-hoc signs the result.
+# Output: ./dock-badge-reader (sibling of this script)
+#
+# After building, you must grant Accessibility permission to the produced
+# binary in System Settings → Privacy & Security → Accessibility, otherwise
+# the helper will exit with code 3.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+OUT="dock-badge-reader"
+
+echo "Compiling $OUT..."
+swiftc -O "$OUT.swift" -o "$OUT"
+
+echo "Ad-hoc signing $OUT..."
+codesign -s - --force "$OUT"
+
+echo
+echo "Built: $(pwd)/$OUT"
+echo
+echo "Next steps:"
+echo "  1. Open System Settings → Privacy & Security → Accessibility"
+echo "  2. Add this binary: $(pwd)/$OUT"
+echo "  3. Restart the LaunchAgent:"
+echo "       launchctl kickstart -k gui/\$(id -u)/net.midwood.messages-icon"

--- a/helper/dock-badge-reader.swift
+++ b/helper/dock-badge-reader.swift
@@ -1,0 +1,112 @@
+import Cocoa
+import ApplicationServices
+import Darwin
+
+// Private but stable since macOS 10.14 — sets the spawned child to be its
+// own responsible process for TCC purposes, instead of inheriting from the
+// parent. Without this, when this helper is spawned by Python under launchd,
+// TCC checks Python's Accessibility grant (the parent) rather than the
+// helper's own grant — and denies. See messages-icon issue #13.
+@_silgen_name("responsibility_spawnattrs_setdisclaim")
+func responsibility_spawnattrs_setdisclaim(_ attrs: UnsafeMutablePointer<posix_spawnattr_t?>, _ disclaim: Int32) -> Int32
+
+let DISCLAIMED_FLAG = "--disclaimed"
+
+func fail(_ message: String, code: Int32) -> Never {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+    exit(code)
+}
+
+func readBadgeAndExit() -> Never {
+    guard AXIsProcessTrusted() else {
+        fail("Accessibility permission not granted to this helper. Add the helper binary in System Settings → Privacy & Security → Accessibility.", code: 3)
+    }
+
+    guard let dock = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == "com.apple.dock" }) else {
+        fail("Dock process not running", code: 2)
+    }
+
+    let dockApp = AXUIElementCreateApplication(dock.processIdentifier)
+
+    var childrenRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(dockApp, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+          let children = childrenRef as? [AXUIElement] else {
+        fail("Could not read Dock children (AX call failed — Accessibility permission may have been revoked)", code: 4)
+    }
+
+    var dockList: AXUIElement?
+    for child in children {
+        var roleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(child, kAXRoleAttribute as CFString, &roleRef)
+        if let role = roleRef as? String, role == (kAXListRole as String) {
+            dockList = child
+            break
+        }
+    }
+
+    guard let list = dockList else {
+        fail("No AXList child found under Dock", code: 5)
+    }
+
+    var tilesRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(list, kAXChildrenAttribute as CFString, &tilesRef) == .success,
+          let tiles = tilesRef as? [AXUIElement] else {
+        fail("Could not read Dock list children", code: 6)
+    }
+
+    for tile in tiles {
+        var titleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(tile, kAXTitleAttribute as CFString, &titleRef)
+        guard let title = titleRef as? String, title == "Messages" else { continue }
+
+        var labelRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(tile, "AXStatusLabel" as CFString, &labelRef) == .success,
+           let label = labelRef as? String, let count = Int(label) {
+            print(count)
+        } else {
+            print(0)
+        }
+        exit(0)
+    }
+
+    fail("Messages tile not found in Dock", code: 7)
+}
+
+// If we're already the disclaimed child, do the work and exit.
+if CommandLine.arguments.contains(DISCLAIMED_FLAG) {
+    readBadgeAndExit()
+}
+
+// Otherwise, re-exec ourselves with disclaim set so the child is its own
+// responsible process for TCC. The parent here just waits and propagates exit.
+var attr: posix_spawnattr_t? = nil
+guard posix_spawnattr_init(&attr) == 0 else {
+    fail("posix_spawnattr_init failed", code: 90)
+}
+defer { posix_spawnattr_destroy(&attr) }
+
+guard responsibility_spawnattrs_setdisclaim(&attr, 1) == 0 else {
+    fail("responsibility_spawnattrs_setdisclaim failed", code: 91)
+}
+
+let selfPath = CommandLine.arguments[0]
+let argv: [String] = [selfPath, DISCLAIMED_FLAG]
+var cArgv: [UnsafeMutablePointer<CChar>?] = argv.map { strdup($0) } + [nil]
+defer { for p in cArgv { if let p = p { free(p) } } }
+
+var pid: pid_t = 0
+let spawnResult = selfPath.withCString { pathPtr -> Int32 in
+    return posix_spawn(&pid, pathPtr, nil, &attr, cArgv, environ)
+}
+
+guard spawnResult == 0 else {
+    fail("posix_spawn failed: \(spawnResult)", code: 92)
+}
+
+var status: Int32 = 0
+waitpid(pid, &status, 0)
+if (status & 0x7f) == 0 {
+    exit((status >> 8) & 0xff)
+} else {
+    fail("disclaimed child terminated by signal \(status & 0x7f)", code: 93)
+}

--- a/server.py
+++ b/server.py
@@ -211,45 +211,41 @@ APPLE_TOUCH_ICON_SVG = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1
 </svg>'''
 
 
+HELPER_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "helper", "dock-badge-reader")
+
+
 def get_unread_count():
-    """Read the Messages dock badge count via the Dock accessibility API.
+    """Read the Messages dock badge count via a compiled Swift helper.
 
-    Uses AppleScript to query the AXStatusLabel attribute of the Messages
-    element in the Dock. This matches the actual dock badge exactly, unlike
-    lsappinfo (which returns NULL for Messages on macOS Tahoe) or direct
-    SQLite queries on chat.db (which return stale iCloud sync data).
+    The helper (helper/dock-badge-reader) calls the Accessibility API
+    directly to read AXStatusLabel on the Messages dock tile. The helper
+    is the TCC subject — Accessibility permission must be granted to it
+    in System Settings, not to the Python interpreter.
 
-    Requires: Accessibility permission for the calling process.
+    See helper/build.sh for build instructions and the project's CLAUDE.md
+    for the rationale (issue #13).
 
     Returns:
         tuple: (count: int, error: str | None)
     """
     try:
         result = subprocess.run(
-            ["osascript", "-e",
-             'tell application "System Events" to tell process "Dock" '
-             'to return value of attribute "AXStatusLabel" of UI element '
-             '"Messages" of list 1'],
-            capture_output=True, text=True, timeout=5,
+            [HELPER_PATH], capture_output=True, text=True, timeout=5,
         )
-        output = result.stdout.strip()
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            if "missing value" in stderr or "missing value" in output:
-                return 0, None
-            return 0, "Could not read Messages badge (check Accessibility permissions)"
-        if not output or output == "missing value":
-            return 0, None
+    except FileNotFoundError:
+        return 0, f"Helper not built. Run {os.path.dirname(HELPER_PATH)}/build.sh"
+    except subprocess.TimeoutExpired:
+        return 0, "Dock badge helper timed out"
+
+    if result.returncode == 0:
         try:
-            return int(output), None
+            return int(result.stdout.strip()), None
         except ValueError:
             return 0, None
-    except FileNotFoundError:
-        return 0, "osascript not found (macOS only)"
-    except subprocess.TimeoutExpired:
-        return 0, "osascript timed out"
-    except Exception as e:
-        return 0, str(e)
+
+    if result.returncode == 3:
+        return 0, "Accessibility permission missing for dock-badge-reader helper"
+    return 0, f"dock-badge-reader exited {result.returncode}: {result.stderr.strip()}"
 
 
 class Handler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## Summary

- Replace the `osascript`-via-Python flow with a small Swift Mach-O at `helper/dock-badge-reader`. TCC's Accessibility grant binds to the helper's stable cdhash, surviving Homebrew Python upgrades.
- The helper self-disclaims TCC responsibility on startup (`responsibility_spawnattrs_setdisclaim` + self-re-exec). Without that, TCC still checks the Python parent as the responsible process and denies the call despite the helper having its own grant. Confirmed via `tccd`'s `AUTHREQ_SUBJECT` log.
- Pattern is documented in `~/bin/CLAUDE.md` (separate commit) so future projects needing TCC permissions follow the same shape.

## Why

Granting Accessibility to the LaunchAgent's Python interpreter silently broke on every Homebrew bump because the cellar path and binary signature both change. Real unread messages were missed because `/api/count` returned `{unread: 0}` indistinguishably from "no messages."

## Test plan

- [x] Helper compiles cleanly (`helper/build.sh`).
- [x] Helper runs from interactive shell and returns the correct unread count.
- [x] After granting Accessibility to the helper binary and restarting the LaunchAgent (`launchctl kickstart -k gui/$(id -u)/net.midwood.messages-icon`), `curl -k https://localhost:8429/api/count` returns `{"unread": <correct count>}` with no error.
- [x] `tccd` log confirms `AUTHREQ_SUBJECT` is now the helper path, not Python.
- [x] PWA on a remote laptop refreshes and shows the correct dock badge count.

## Migration notes for any future re-clone

After cloning fresh:
1. `./helper/build.sh`
2. Grant Accessibility to `helper/dock-badge-reader` in System Settings.
3. Start the server.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)