### PR TITLE
fix: show indeterminate dock badge when /api/count errors

### DIFF
--- a/server.py
+++ b/server.py
@@ -162,9 +162,13 @@ function update(data) {{
 
     drawFavicon(count);
 
-    // PWA Badging API — updates the dock icon badge for installed web apps
+    // PWA Badging API — updates the dock icon badge for installed web apps.
+    // On error, show an indeterminate dot so a broken read isn't indistinguishable
+    // from "0 unread" (see issue #14).
     if ('setAppBadge' in navigator) {{
-        if (count > 0) {{
+        if (data.error) {{
+            navigator.setAppBadge();
+        }} else if (count > 0) {{
             navigator.setAppBadge(count);
         }} else {{
             navigator.clearAppBadge();
@@ -179,6 +183,9 @@ async function poll() {{
         update(data);
     }} catch (e) {{
         document.getElementById('error').textContent = 'Connection lost';
+        if ('setAppBadge' in navigator) {{
+            navigator.setAppBadge();
+        }}
     }}
 }}
 


### PR DESCRIPTION
## Summary
- When the helper fails (Accessibility revoked, timeout, missing binary) or the fetch itself fails, the dock badge previously got cleared — making a broken read look identical to "0 unread" and silently hiding real messages.
- Both error paths now call `navigator.setAppBadge()` with no argument, so the OS shows an indeterminate dot signalling that the app needs attention.
- Note: the Badging API doesn't expose color control, so the dot is whatever color the OS picks (typically the same color as a normal badge), not specifically yellow. The issue body acknowledges this.

Closes #14

## Test plan
- [x] Induced error by moving `helper/dock-badge-reader` aside; `/api/count` returned `{"unread": 0, "error": "Helper not built..."}`; dot appeared in the installed PWA dock.
- [x] Restored helper; `/api/count` returned `{"unread": 0}`; dot cleared.
- [ ] Connection-lost path (server stopped) — covered by the same `setAppBadge()` call in the `poll()` catch block; not separately exercised but follows the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)